### PR TITLE
PBI 20&29: Filter vendors by product

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -39,6 +39,7 @@ jobs:
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.exclusions=**/vendor/**,**/*_mock.go,internal/common/database/**
             -Dsonar.coverage.exclusions=**/router/**,**/accessor.go,**/vendor/**,**/*_mock.go,**/*_test.go,**/cmd/**/*.*
+            -Dsonar.cpd.exclusions=**/accessor.go,**/*.sql
             -Dsonar.language=go
             -Dsonar.sourceEncoding=UTF-8
         env:

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -30,6 +30,7 @@ type Routes struct {
 type VendorRoutes struct {
 	GetAll        string `mapstructure:"get-all" validate:"required"`
 	GetByLocation string `mapstructure:"get-by-location" validate:"required"`
+	GetByProduct  string `mapstructure:"get-by-product" validate:"required"`
 }
 
 func Load() Application {

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -11,7 +11,8 @@
   "routes": {
     "vendor": {
       "get-all": "/vendor",
-      "get-by-location": "/vendor/location"
+      "get-by-location": "/vendor/location",
+      "get-by-product": "/vendor/product"
     }
   }
 }

--- a/internal/vendors/accessor.go
+++ b/internal/vendors/accessor.go
@@ -144,14 +144,11 @@ func (p *postgresVendorAccessor) GetByLocation(ctx context.Context, location str
 	return vendors, nil
 }
 
-func (p *postgresVendorAccessor) GetByProduct(ctx context.Context, product string) ([]Vendor, error) {
-	// Split the product string into words
-	words := strings.Fields(product)
-
+func (p *postgresVendorAccessor) GetByProductWords(ctx context.Context, productWords []string) ([]Vendor, error) {
 	// Build the WHERE clause dynamically
 	var whereClauses []string
 	var args []interface{}
-	for i, word := range words {
+	for i, word := range productWords {
 		whereClauses = append(whereClauses, fmt.Sprintf("description LIKE $%d", i+1))
 		args = append(args, "%"+word+"%")
 	}

--- a/internal/vendors/accessor.go
+++ b/internal/vendors/accessor.go
@@ -77,7 +77,7 @@ func (p *postgresVendorAccessor) GetAll(ctx context.Context) ([]Vendor, error) {
 			&vendor.Date,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("Failed while scanning row: %w", err)
+			return nil, err
 		}
 		vendors = append(vendors, vendor)
 	}
@@ -132,7 +132,7 @@ func (p *postgresVendorAccessor) GetByLocation(ctx context.Context, location str
 			&vendor.Date,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("Failed while scanning row: %w", err)
+			return nil, err
 		}
 		vendors = append(vendors, vendor)
 	}
@@ -197,7 +197,7 @@ func (p *postgresVendorAccessor) GetByProductWords(ctx context.Context, productW
 			&vendor.Date,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("Failed while scanning row: %w", err)
+			return nil, err
 		}
 		vendors = append(vendors, vendor)
 	}

--- a/internal/vendors/accessor.go
+++ b/internal/vendors/accessor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"kg/procurement/internal/common/database"
+	"strings"
 )
 
 type postgresVendorAccessor struct {
@@ -144,7 +145,70 @@ func (p *postgresVendorAccessor) GetByLocation(ctx context.Context, location str
 }
 
 func (p *postgresVendorAccessor) GetByProduct(ctx context.Context, product string) ([]Vendor, error) {
+	// Split the product string into words
+	words := strings.Fields(product)
+
+	// Build the WHERE clause dynamically
+	var whereClauses []string
+	var args []interface{}
+	for i, word := range words {
+		whereClauses = append(whereClauses, fmt.Sprintf("description LIKE $%d", i+1))
+		args = append(args, "%"+word+"%")
+	}
+	whereClause := strings.Join(whereClauses, " AND ")
+
+	// Construct the final query
+	query := fmt.Sprintf(`SELECT 
+        "id",
+        "name",
+        "description",
+        "bp_id",
+        "bp_name",
+        "rating",
+        "area_group_id",
+        "area_group_name",
+        "sap_code",
+        "modified_date",
+        "modified_by",
+        "dt" 
+        FROM vendor
+        WHERE %s`, whereClause)
+
+	rows, err := p.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
 	vendors := []Vendor{}
+
+	for rows.Next() {
+		var vendor Vendor
+		err := rows.Scan(
+			&vendor.ID,
+			&vendor.Name,
+			&vendor.Description,
+			&vendor.BpID,
+			&vendor.BpName,
+			&vendor.Rating,
+			&vendor.AreaGroupID,
+			&vendor.AreaGroupName,
+			&vendor.SapCode,
+			&vendor.ModifiedDate,
+			&vendor.ModifiedBy,
+			&vendor.Date,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("Failed while scanning row: %w", err)
+		}
+		vendors = append(vendors, vendor)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return vendors, nil
 }
 

--- a/internal/vendors/accessor.go
+++ b/internal/vendors/accessor.go
@@ -144,11 +144,11 @@ func (p *postgresVendorAccessor) GetByLocation(ctx context.Context, location str
 	return vendors, nil
 }
 
-func (p *postgresVendorAccessor) GetByProductWords(ctx context.Context, productWords []string) ([]Vendor, error) {
+func (p *postgresVendorAccessor) GetByProductDescription(ctx context.Context, productDescription []string) ([]Vendor, error) {
 	// Build the WHERE clause dynamically
 	var whereClauses []string
 	var args []interface{}
-	for i, word := range productWords {
+	for i, word := range productDescription {
 		whereClauses = append(whereClauses, fmt.Sprintf("description LIKE $%d", i+1))
 		args = append(args, "%"+word+"%")
 	}

--- a/internal/vendors/accessor.go
+++ b/internal/vendors/accessor.go
@@ -143,6 +143,11 @@ func (p *postgresVendorAccessor) GetByLocation(ctx context.Context, location str
 	return vendors, nil
 }
 
+func (p *postgresVendorAccessor) GetByProduct(ctx context.Context, product string) ([]Vendor, error) {
+	vendors := []Vendor{}
+	return vendors, nil
+}
+
 // newPostgresVendorAccessor is only accessible by the vendor package
 // entrypoint for other verticals should refer to the interface declared on service
 func newPostgresVendorAccessor(db database.DBConnector) *postgresVendorAccessor {

--- a/internal/vendors/accessor_test.go
+++ b/internal/vendors/accessor_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -472,22 +473,6 @@ func TestVendorAccessor_GetByLocation(t *testing.T) {
 		g, db := setup(t)
 		defer db.Close()
 
-		rows := sqlmock.NewRows(sampleData).
-			AddRow(
-				"1",
-				"name",
-				"description",
-				"1",
-				"bp_name",
-				1,
-				"1",
-				location,
-				"sap_code",
-				fixedTime,
-				1,
-				fixedTime,
-			)
-
 		wrongQuery := `SELECT 
 			"id",
 			"name",
@@ -505,7 +490,8 @@ func TestVendorAccessor_GetByLocation(t *testing.T) {
 			WHERE description = $1`
 
 		mock.ExpectQuery(wrongQuery).
-			WillReturnRows(rows)
+			WithArgs(location).
+			WillReturnError(errors.New("some error"))
 
 		ctx := context.Background()
 		res, err := accessor.GetByLocation(ctx, location)
@@ -535,10 +521,270 @@ func TestVendorAccessor_GetByLocation(t *testing.T) {
 			).RowError(0, fmt.Errorf("row error"))
 
 		mock.ExpectQuery(query).
+			WithArgs(location).
 			WillReturnRows(rows)
 
 		ctx := context.Background()
 		res, err := accessor.GetByLocation(ctx, location)
+
+		g.Expect(err).ToNot(gomega.BeNil())
+		g.Expect(res).To(gomega.BeNil())
+	})
+}
+
+func TestVendorAccessor_GetByProduct(t *testing.T) {
+	t.Parallel()
+
+	var (
+		accessor *postgresVendorAccessor
+		mock     sqlmock.Sqlmock
+	)
+
+	setup := func(t *testing.T) (*gomega.GomegaWithT, *sql.DB) {
+		g := gomega.NewWithT(t)
+		db, sqlMock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		if err != nil {
+			log.Fatal("error initializing mock:", err)
+		}
+
+		accessor = newPostgresVendorAccessor(db)
+		mock = sqlMock
+
+		return g, db
+	}
+
+	sampleData := []string{
+		"id",
+		"name",
+		"description",
+		"bp_id",
+		"bp_name",
+		"rating",
+		"area_group_id",
+		"area_group_name",
+		"sap_code",
+		"modified_date",
+		"modified_by",
+		"dt",
+	}
+
+	fixedTime := time.Date(2024, time.September, 27, 12, 30, 0, 0, time.UTC)
+	product := "test product"
+	productParts := strings.Fields(product)
+
+	t.Run("success", func(t *testing.T) {
+		g, db := setup(t)
+		defer db.Close()
+
+		query := `SELECT 
+			"id",
+			"name",
+			"description",
+			"bp_id",
+			"bp_name",
+			"rating",
+			"area_group_id",
+			"area_group_name",
+			"sap_code",
+			"modified_date",
+			"modified_by",
+			"dt" 
+			FROM vendor
+			WHERE description LIKE $1 AND description LIKE $2`
+
+		rows := sqlmock.NewRows(sampleData).
+			AddRow(
+				"1",
+				"name",
+				"description",
+				"1",
+				"bp_name",
+				1,
+				"1",
+				"group_name",
+				"sap_code",
+				fixedTime,
+				1,
+				fixedTime,
+			)
+
+		mock.ExpectQuery(query).
+			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WillReturnRows(rows)
+
+		ctx := context.Background()
+		res, err := accessor.GetByProduct(ctx, product)
+
+		expectation := []Vendor{{
+			ID:            "1",
+			Name:          "name",
+			Description:   "description",
+			BpID:          "1",
+			BpName:        "bp_name",
+			Rating:        1,
+			AreaGroupID:   "1",
+			AreaGroupName: "group_name",
+			SapCode:       "sap_code",
+			ModifiedDate:  fixedTime,
+			ModifiedBy:    1,
+			Date:          fixedTime,
+		}}
+
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(res).To(gomega.Equal(expectation))
+	})
+
+	t.Run("success on empty result", func(t *testing.T) {
+		g, db := setup(t)
+		defer db.Close()
+
+		query := `SELECT 
+			"id",
+			"name",
+			"description",
+			"bp_id",
+			"bp_name",
+			"rating",
+			"area_group_id",
+			"area_group_name",
+			"sap_code",
+			"modified_date",
+			"modified_by",
+			"dt" 
+			FROM vendor
+			WHERE description LIKE $1 AND description LIKE $2`
+
+		rows := sqlmock.NewRows(sampleData)
+
+		mock.ExpectQuery(query).
+			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WillReturnRows(rows)
+
+		ctx := context.Background()
+		res, err := accessor.GetByProduct(ctx, product)
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(res).To(gomega.Equal([]Vendor{}))
+	})
+
+	t.Run("error on scanning row", func(t *testing.T) {
+		g, db := setup(t)
+		defer db.Close()
+
+		query := `SELECT 
+			"id",
+			"name",
+			"description",
+			"bp_id",
+			"bp_name",
+			"rating",
+			"area_group_id",
+			"area_group_name",
+			"sap_code",
+			"modified_date",
+			"modified_by",
+			"dt" 
+			FROM vendor
+			WHERE description LIKE $1 AND description LIKE $2`
+
+		rows := sqlmock.NewRows(sampleData).AddRow(
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		mock.ExpectQuery(query).
+			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WillReturnRows(rows)
+
+		ctx := context.Background()
+		res, err := accessor.GetByProduct(ctx, product)
+
+		g.Expect(err).ToNot(gomega.BeNil())
+		g.Expect(res).To(gomega.BeNil())
+	})
+
+	t.Run("error on executing query", func(t *testing.T) {
+		g, db := setup(t)
+		defer db.Close()
+
+		query := `SELECT 
+			"id",
+			"name",
+			"description",
+			"bp_id",
+			"bp_name",
+			"rating",
+			"area_group_id",
+			"area_group_name",
+			"sap_code",
+			"modified_date",
+			"modified_by",
+			"dt" 
+			FROM vendor
+			WHERE description LIKE $1 AND description LIKE $2`
+
+		mock.ExpectQuery(query).
+			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WillReturnError(errors.New("some error"))
+
+		ctx := context.Background()
+		res, err := accessor.GetByProduct(ctx, product)
+
+		g.Expect(err).ToNot(gomega.BeNil())
+		g.Expect(res).To(gomega.BeNil())
+	})
+
+	t.Run("error while iterating rows", func(t *testing.T) {
+		g, db := setup(t)
+		defer db.Close()
+
+		query := `SELECT 
+			"id",
+			"name",
+			"description",
+			"bp_id",
+			"bp_name",
+			"rating",
+			"area_group_id",
+			"area_group_name",
+			"sap_code",
+			"modified_date",
+			"modified_by",
+			"dt" 
+			FROM vendor
+			WHERE description LIKE $1 AND description LIKE $2`
+
+		rows := sqlmock.NewRows(sampleData).
+			AddRow(
+				"1",
+				"name",
+				"description",
+				"1",
+				"bp_name",
+				1,
+				"1",
+				"group_name",
+				"sap_code",
+				fixedTime,
+				1,
+				fixedTime,
+			).RowError(0, fmt.Errorf("row error"))
+
+		mock.ExpectQuery(query).
+			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WillReturnRows(rows)
+
+		ctx := context.Background()
+		res, err := accessor.GetByProduct(ctx, product)
 
 		g.Expect(err).ToNot(gomega.BeNil())
 		g.Expect(res).To(gomega.BeNil())

--- a/internal/vendors/accessor_test.go
+++ b/internal/vendors/accessor_test.go
@@ -358,20 +358,20 @@ func TestVendorAccessor_GetByLocation(t *testing.T) {
 	}
 
 	query := `SELECT 
-	"id",
-	"name",
-	"description",
-	"bp_id",
-	"bp_name",
-	"rating",
-	"area_group_id",
-	"area_group_name",
-	"sap_code",
-	"modified_date",
-	"modified_by",
-	"dt" 
-	FROM vendor
-	WHERE area_group_name = $1`
+			"id",
+			"name",
+			"description",
+			"bp_id",
+			"bp_name",
+			"rating",
+			"area_group_id",
+			"area_group_name",
+			"sap_code",
+			"modified_date",
+			"modified_by",
+			"dt" 
+			FROM vendor
+			WHERE area_group_name = $1`
 
 	fixedTime := time.Date(2024, time.September, 27, 12, 30, 0, 0, time.UTC)
 
@@ -473,23 +473,7 @@ func TestVendorAccessor_GetByLocation(t *testing.T) {
 		g, db := setup(t)
 		defer db.Close()
 
-		wrongQuery := `SELECT 
-			"id",
-			"name",
-			"description",
-			"bp_id",
-			"bp_name",
-			"rating",
-			"area_group_id",
-			"area_group_name",
-			"sap_code",
-			"modified_date",
-			"modified_by",
-			"dt" 
-			FROM vendor
-			WHERE description = $1`
-
-		mock.ExpectQuery(wrongQuery).
+		mock.ExpectQuery(query).
 			WithArgs(location).
 			WillReturnError(errors.New("some error"))
 
@@ -568,15 +552,7 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 		"dt",
 	}
 
-	fixedTime := time.Date(2024, time.September, 27, 12, 30, 0, 0, time.UTC)
-	product := "test product"
-	productParts := strings.Fields(product)
-
-	t.Run("success", func(t *testing.T) {
-		g, db := setup(t)
-		defer db.Close()
-
-		query := `SELECT 
+	query := `SELECT 
 			"id",
 			"name",
 			"description",
@@ -591,6 +567,14 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 			"dt" 
 			FROM vendor
 			WHERE description LIKE $1 AND description LIKE $2`
+
+	fixedTime := time.Date(2024, time.September, 27, 12, 30, 0, 0, time.UTC)
+	product := "test product"
+	productParts := strings.Fields(product)
+
+	t.Run("success", func(t *testing.T) {
+		g, db := setup(t)
+		defer db.Close()
 
 		rows := sqlmock.NewRows(sampleData).
 			AddRow(
@@ -638,22 +622,6 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 		g, db := setup(t)
 		defer db.Close()
 
-		query := `SELECT 
-			"id",
-			"name",
-			"description",
-			"bp_id",
-			"bp_name",
-			"rating",
-			"area_group_id",
-			"area_group_name",
-			"sap_code",
-			"modified_date",
-			"modified_by",
-			"dt" 
-			FROM vendor
-			WHERE description LIKE $1 AND description LIKE $2`
-
 		rows := sqlmock.NewRows(sampleData)
 
 		mock.ExpectQuery(query).
@@ -669,22 +637,6 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 	t.Run("error on scanning row", func(t *testing.T) {
 		g, db := setup(t)
 		defer db.Close()
-
-		query := `SELECT 
-			"id",
-			"name",
-			"description",
-			"bp_id",
-			"bp_name",
-			"rating",
-			"area_group_id",
-			"area_group_name",
-			"sap_code",
-			"modified_date",
-			"modified_by",
-			"dt" 
-			FROM vendor
-			WHERE description LIKE $1 AND description LIKE $2`
 
 		rows := sqlmock.NewRows(sampleData).AddRow(
 			nil,
@@ -716,22 +668,6 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 		g, db := setup(t)
 		defer db.Close()
 
-		query := `SELECT 
-			"id",
-			"name",
-			"description",
-			"bp_id",
-			"bp_name",
-			"rating",
-			"area_group_id",
-			"area_group_name",
-			"sap_code",
-			"modified_date",
-			"modified_by",
-			"dt" 
-			FROM vendor
-			WHERE description LIKE $1 AND description LIKE $2`
-
 		mock.ExpectQuery(query).
 			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
 			WillReturnError(errors.New("some error"))
@@ -746,22 +682,6 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 	t.Run("error while iterating rows", func(t *testing.T) {
 		g, db := setup(t)
 		defer db.Close()
-
-		query := `SELECT 
-			"id",
-			"name",
-			"description",
-			"bp_id",
-			"bp_name",
-			"rating",
-			"area_group_id",
-			"area_group_name",
-			"sap_code",
-			"modified_date",
-			"modified_by",
-			"dt" 
-			FROM vendor
-			WHERE description LIKE $1 AND description LIKE $2`
 
 		rows := sqlmock.NewRows(sampleData).
 			AddRow(

--- a/internal/vendors/accessor_test.go
+++ b/internal/vendors/accessor_test.go
@@ -516,7 +516,7 @@ func TestVendorAccessor_GetByLocation(t *testing.T) {
 	})
 }
 
-func TestVendorAccessor_GetByProduct(t *testing.T) {
+func TestVendorAccessor_GetByProductWords(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -570,7 +570,7 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 
 	fixedTime := time.Date(2024, time.September, 27, 12, 30, 0, 0, time.UTC)
 	product := "test product"
-	productParts := strings.Fields(product)
+	productWords := strings.Fields(product)
 
 	t.Run("success", func(t *testing.T) {
 		g, db := setup(t)
@@ -593,11 +593,11 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 			)
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
 			WillReturnRows(rows)
 
 		ctx := context.Background()
-		res, err := accessor.GetByProduct(ctx, product)
+		res, err := accessor.GetByProductWords(ctx, productWords)
 
 		expectation := []Vendor{{
 			ID:            "1",
@@ -625,11 +625,11 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 		rows := sqlmock.NewRows(sampleData)
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
 			WillReturnRows(rows)
 
 		ctx := context.Background()
-		res, err := accessor.GetByProduct(ctx, product)
+		res, err := accessor.GetByProductWords(ctx, productWords)
 		g.Expect(err).To(gomega.BeNil())
 		g.Expect(res).To(gomega.Equal([]Vendor{}))
 	})
@@ -654,11 +654,11 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 		)
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
 			WillReturnRows(rows)
 
 		ctx := context.Background()
-		res, err := accessor.GetByProduct(ctx, product)
+		res, err := accessor.GetByProductWords(ctx, productWords)
 
 		g.Expect(err).ToNot(gomega.BeNil())
 		g.Expect(res).To(gomega.BeNil())
@@ -669,11 +669,11 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 		defer db.Close()
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
 			WillReturnError(errors.New("some error"))
 
 		ctx := context.Background()
-		res, err := accessor.GetByProduct(ctx, product)
+		res, err := accessor.GetByProductWords(ctx, productWords)
 
 		g.Expect(err).ToNot(gomega.BeNil())
 		g.Expect(res).To(gomega.BeNil())
@@ -700,11 +700,11 @@ func TestVendorAccessor_GetByProduct(t *testing.T) {
 			).RowError(0, fmt.Errorf("row error"))
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productParts[0]+"%", "%"+productParts[1]+"%").
+			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
 			WillReturnRows(rows)
 
 		ctx := context.Background()
-		res, err := accessor.GetByProduct(ctx, product)
+		res, err := accessor.GetByProductWords(ctx, productWords)
 
 		g.Expect(err).ToNot(gomega.BeNil())
 		g.Expect(res).To(gomega.BeNil())

--- a/internal/vendors/accessor_test.go
+++ b/internal/vendors/accessor_test.go
@@ -516,7 +516,7 @@ func TestVendorAccessor_GetByLocation(t *testing.T) {
 	})
 }
 
-func TestVendorAccessor_GetByProductWords(t *testing.T) {
+func TestVendorAccessor_GetByProductDescription(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -570,7 +570,7 @@ func TestVendorAccessor_GetByProductWords(t *testing.T) {
 
 	fixedTime := time.Date(2024, time.September, 27, 12, 30, 0, 0, time.UTC)
 	product := "test product"
-	productWords := strings.Fields(product)
+	productDescription := strings.Fields(product)
 
 	t.Run("success", func(t *testing.T) {
 		g, db := setup(t)
@@ -593,11 +593,11 @@ func TestVendorAccessor_GetByProductWords(t *testing.T) {
 			)
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
+			WithArgs("%"+productDescription[0]+"%", "%"+productDescription[1]+"%").
 			WillReturnRows(rows)
 
 		ctx := context.Background()
-		res, err := accessor.GetByProductWords(ctx, productWords)
+		res, err := accessor.GetByProductDescription(ctx, productDescription)
 
 		expectation := []Vendor{{
 			ID:            "1",
@@ -625,11 +625,11 @@ func TestVendorAccessor_GetByProductWords(t *testing.T) {
 		rows := sqlmock.NewRows(sampleData)
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
+			WithArgs("%"+productDescription[0]+"%", "%"+productDescription[1]+"%").
 			WillReturnRows(rows)
 
 		ctx := context.Background()
-		res, err := accessor.GetByProductWords(ctx, productWords)
+		res, err := accessor.GetByProductDescription(ctx, productDescription)
 		g.Expect(err).To(gomega.BeNil())
 		g.Expect(res).To(gomega.Equal([]Vendor{}))
 	})
@@ -654,11 +654,11 @@ func TestVendorAccessor_GetByProductWords(t *testing.T) {
 		)
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
+			WithArgs("%"+productDescription[0]+"%", "%"+productDescription[1]+"%").
 			WillReturnRows(rows)
 
 		ctx := context.Background()
-		res, err := accessor.GetByProductWords(ctx, productWords)
+		res, err := accessor.GetByProductDescription(ctx, productDescription)
 
 		g.Expect(err).ToNot(gomega.BeNil())
 		g.Expect(res).To(gomega.BeNil())
@@ -669,11 +669,11 @@ func TestVendorAccessor_GetByProductWords(t *testing.T) {
 		defer db.Close()
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
+			WithArgs("%"+productDescription[0]+"%", "%"+productDescription[1]+"%").
 			WillReturnError(errors.New("some error"))
 
 		ctx := context.Background()
-		res, err := accessor.GetByProductWords(ctx, productWords)
+		res, err := accessor.GetByProductDescription(ctx, productDescription)
 
 		g.Expect(err).ToNot(gomega.BeNil())
 		g.Expect(res).To(gomega.BeNil())
@@ -700,11 +700,11 @@ func TestVendorAccessor_GetByProductWords(t *testing.T) {
 			).RowError(0, fmt.Errorf("row error"))
 
 		mock.ExpectQuery(query).
-			WithArgs("%"+productWords[0]+"%", "%"+productWords[1]+"%").
+			WithArgs("%"+productDescription[0]+"%", "%"+productDescription[1]+"%").
 			WillReturnRows(rows)
 
 		ctx := context.Background()
-		res, err := accessor.GetByProductWords(ctx, productWords)
+		res, err := accessor.GetByProductDescription(ctx, productDescription)
 
 		g.Expect(err).ToNot(gomega.BeNil())
 		g.Expect(res).To(gomega.BeNil())

--- a/internal/vendors/service.go
+++ b/internal/vendors/service.go
@@ -4,13 +4,14 @@ package vendors
 import (
 	"context"
 	"kg/procurement/internal/common/database"
+	"strings"
 )
 
 type vendorDBAccessor interface {
 	GetSomeStuff(ctx context.Context) ([]string, error)
 	GetAll(ctx context.Context) ([]Vendor, error)
 	GetByLocation(ctx context.Context, location string) ([]Vendor, error)
-	GetByProduct(ctx context.Context, product string) ([]Vendor, error)
+	GetByProductWords(ctx context.Context, productWords []string) ([]Vendor, error)
 }
 
 type VendorService struct {
@@ -30,7 +31,8 @@ func (v *VendorService) GetByLocation(ctx context.Context, location string) ([]V
 }
 
 func (v *VendorService) GetByProduct(ctx context.Context, product string) ([]Vendor, error) {
-	return v.vendorDBAccessor.GetByProduct(ctx, product)
+	productWords := strings.Fields(product)
+	return v.vendorDBAccessor.GetByProductWords(ctx, productWords)
 }
 
 func NewVendorService(

--- a/internal/vendors/service.go
+++ b/internal/vendors/service.go
@@ -10,6 +10,7 @@ type vendorDBAccessor interface {
 	GetSomeStuff(ctx context.Context) ([]string, error)
 	GetAll(ctx context.Context) ([]Vendor, error)
 	GetByLocation(ctx context.Context, location string) ([]Vendor, error)
+	GetByProduct(ctx context.Context, product string) ([]Vendor, error)
 }
 
 type VendorService struct {
@@ -26,6 +27,10 @@ func (v *VendorService) GetAll(ctx context.Context) ([]Vendor, error) {
 
 func (v *VendorService) GetByLocation(ctx context.Context, location string) ([]Vendor, error) {
 	return v.vendorDBAccessor.GetByLocation(ctx, location)
+}
+
+func (v *VendorService) GetByProduct(ctx context.Context, product string) ([]Vendor, error) {
+	return v.vendorDBAccessor.GetByProduct(ctx, product)
 }
 
 func NewVendorService(

--- a/internal/vendors/service.go
+++ b/internal/vendors/service.go
@@ -11,7 +11,7 @@ type vendorDBAccessor interface {
 	GetSomeStuff(ctx context.Context) ([]string, error)
 	GetAll(ctx context.Context) ([]Vendor, error)
 	GetByLocation(ctx context.Context, location string) ([]Vendor, error)
-	GetByProductWords(ctx context.Context, productWords []string) ([]Vendor, error)
+	GetByProductDescription(ctx context.Context, productDescription []string) ([]Vendor, error)
 }
 
 type VendorService struct {
@@ -31,8 +31,8 @@ func (v *VendorService) GetByLocation(ctx context.Context, location string) ([]V
 }
 
 func (v *VendorService) GetByProduct(ctx context.Context, product string) ([]Vendor, error) {
-	productWords := strings.Fields(product)
-	return v.vendorDBAccessor.GetByProductWords(ctx, productWords)
+	productDescription := strings.Fields(product)
+	return v.vendorDBAccessor.GetByProductDescription(ctx, productDescription)
 }
 
 func NewVendorService(

--- a/internal/vendors/service_mock.go
+++ b/internal/vendors/service_mock.go
@@ -117,41 +117,41 @@ func (c *MockvendorDBAccessorGetByLocationCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// GetByProduct mocks base method.
-func (m *MockvendorDBAccessor) GetByProduct(ctx context.Context, product string) ([]Vendor, error) {
+// GetByProductWords mocks base method.
+func (m *MockvendorDBAccessor) GetByProductWords(ctx context.Context, productWords []string) ([]Vendor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByProduct", ctx, product)
+	ret := m.ctrl.Call(m, "GetByProductWords", ctx, productWords)
 	ret0, _ := ret[0].([]Vendor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetByProduct indicates an expected call of GetByProduct.
-func (mr *MockvendorDBAccessorMockRecorder) GetByProduct(ctx, product any) *MockvendorDBAccessorGetByProductCall {
+// GetByProductWords indicates an expected call of GetByProductWords.
+func (mr *MockvendorDBAccessorMockRecorder) GetByProductWords(ctx, productWords any) *MockvendorDBAccessorGetByProductWordsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByProduct", reflect.TypeOf((*MockvendorDBAccessor)(nil).GetByProduct), ctx, product)
-	return &MockvendorDBAccessorGetByProductCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByProductWords", reflect.TypeOf((*MockvendorDBAccessor)(nil).GetByProductWords), ctx, productWords)
+	return &MockvendorDBAccessorGetByProductWordsCall{Call: call}
 }
 
-// MockvendorDBAccessorGetByProductCall wrap *gomock.Call
-type MockvendorDBAccessorGetByProductCall struct {
+// MockvendorDBAccessorGetByProductWordsCall wrap *gomock.Call
+type MockvendorDBAccessorGetByProductWordsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockvendorDBAccessorGetByProductCall) Return(arg0 []Vendor, arg1 error) *MockvendorDBAccessorGetByProductCall {
+func (c *MockvendorDBAccessorGetByProductWordsCall) Return(arg0 []Vendor, arg1 error) *MockvendorDBAccessorGetByProductWordsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockvendorDBAccessorGetByProductCall) Do(f func(context.Context, string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductCall {
+func (c *MockvendorDBAccessorGetByProductWordsCall) Do(f func(context.Context, []string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductWordsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockvendorDBAccessorGetByProductCall) DoAndReturn(f func(context.Context, string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductCall {
+func (c *MockvendorDBAccessorGetByProductWordsCall) DoAndReturn(f func(context.Context, []string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductWordsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/vendors/service_mock.go
+++ b/internal/vendors/service_mock.go
@@ -117,41 +117,41 @@ func (c *MockvendorDBAccessorGetByLocationCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
-// GetByProductWords mocks base method.
-func (m *MockvendorDBAccessor) GetByProductWords(ctx context.Context, productWords []string) ([]Vendor, error) {
+// GetByProductDescription mocks base method.
+func (m *MockvendorDBAccessor) GetByProductDescription(ctx context.Context, productDescription []string) ([]Vendor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByProductWords", ctx, productWords)
+	ret := m.ctrl.Call(m, "GetByProductDescription", ctx, productDescription)
 	ret0, _ := ret[0].([]Vendor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetByProductWords indicates an expected call of GetByProductWords.
-func (mr *MockvendorDBAccessorMockRecorder) GetByProductWords(ctx, productWords any) *MockvendorDBAccessorGetByProductWordsCall {
+// GetByProductDescription indicates an expected call of GetByProductDescription.
+func (mr *MockvendorDBAccessorMockRecorder) GetByProductDescription(ctx, productDescription any) *MockvendorDBAccessorGetByProductDescriptionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByProductWords", reflect.TypeOf((*MockvendorDBAccessor)(nil).GetByProductWords), ctx, productWords)
-	return &MockvendorDBAccessorGetByProductWordsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByProductDescription", reflect.TypeOf((*MockvendorDBAccessor)(nil).GetByProductDescription), ctx, productDescription)
+	return &MockvendorDBAccessorGetByProductDescriptionCall{Call: call}
 }
 
-// MockvendorDBAccessorGetByProductWordsCall wrap *gomock.Call
-type MockvendorDBAccessorGetByProductWordsCall struct {
+// MockvendorDBAccessorGetByProductDescriptionCall wrap *gomock.Call
+type MockvendorDBAccessorGetByProductDescriptionCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockvendorDBAccessorGetByProductWordsCall) Return(arg0 []Vendor, arg1 error) *MockvendorDBAccessorGetByProductWordsCall {
+func (c *MockvendorDBAccessorGetByProductDescriptionCall) Return(arg0 []Vendor, arg1 error) *MockvendorDBAccessorGetByProductDescriptionCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockvendorDBAccessorGetByProductWordsCall) Do(f func(context.Context, []string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductWordsCall {
+func (c *MockvendorDBAccessorGetByProductDescriptionCall) Do(f func(context.Context, []string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductDescriptionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockvendorDBAccessorGetByProductWordsCall) DoAndReturn(f func(context.Context, []string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductWordsCall {
+func (c *MockvendorDBAccessorGetByProductDescriptionCall) DoAndReturn(f func(context.Context, []string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductDescriptionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/vendors/service_mock.go
+++ b/internal/vendors/service_mock.go
@@ -117,6 +117,45 @@ func (c *MockvendorDBAccessorGetByLocationCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
+// GetByProduct mocks base method.
+func (m *MockvendorDBAccessor) GetByProduct(ctx context.Context, product string) ([]Vendor, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByProduct", ctx, product)
+	ret0, _ := ret[0].([]Vendor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByProduct indicates an expected call of GetByProduct.
+func (mr *MockvendorDBAccessorMockRecorder) GetByProduct(ctx, product any) *MockvendorDBAccessorGetByProductCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByProduct", reflect.TypeOf((*MockvendorDBAccessor)(nil).GetByProduct), ctx, product)
+	return &MockvendorDBAccessorGetByProductCall{Call: call}
+}
+
+// MockvendorDBAccessorGetByProductCall wrap *gomock.Call
+type MockvendorDBAccessorGetByProductCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockvendorDBAccessorGetByProductCall) Return(arg0 []Vendor, arg1 error) *MockvendorDBAccessorGetByProductCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockvendorDBAccessorGetByProductCall) Do(f func(context.Context, string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockvendorDBAccessorGetByProductCall) DoAndReturn(f func(context.Context, string) ([]Vendor, error)) *MockvendorDBAccessorGetByProductCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetSomeStuff mocks base method.
 func (m *MockvendorDBAccessor) GetSomeStuff(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/vendors/service_test.go
+++ b/internal/vendors/service_test.go
@@ -272,14 +272,14 @@ func TestVendorService_GetByProduct(t *testing.T) {
 				vendorDBAccessor: tt.fields.mockVendorDBAccessor,
 			}
 
-			productWords := strings.Fields(tt.args.product)
+			productDescription := strings.Fields(tt.args.product)
 			if tt.wantErr {
 				tt.fields.mockVendorDBAccessor.EXPECT().
-					GetByProductWords(tt.args.ctx, productWords).
+					GetByProductDescription(tt.args.ctx, productDescription).
 					Return(nil, fmt.Errorf("some error"))
 			} else {
 				tt.fields.mockVendorDBAccessor.EXPECT().
-					GetByProductWords(tt.args.ctx, productWords).
+					GetByProductDescription(tt.args.ctx, productDescription).
 					Return(tt.want, nil)
 			}
 

--- a/internal/vendors/service_test.go
+++ b/internal/vendors/service_test.go
@@ -204,3 +204,92 @@ func TestVendorService_GetByLocation(t *testing.T) {
 		})
 	}
 }
+
+func TestVendorService_GetByProduct(t *testing.T) {
+	product := "ProductA"
+	sampleData := []Vendor{
+		{
+			ID:            "1",
+			Name:          "name",
+			Description:   "description",
+			BpID:          "1",
+			BpName:        "bp_name",
+			Rating:        1,
+			AreaGroupID:   "1",
+			AreaGroupName: "group_name",
+			SapCode:       "sap_code",
+			ModifiedDate:  time.Now(),
+			ModifiedBy:    1,
+			Date:          time.Now(),
+		},
+	}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	type fields struct {
+		mockVendorDBAccessor *MockvendorDBAccessor
+	}
+	type args struct {
+		ctx     context.Context
+		product string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []Vendor
+		wantErr bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				mockVendorDBAccessor: NewMockvendorDBAccessor(ctrl),
+			},
+			args: args{
+				ctx:     context.Background(),
+				product: product,
+			},
+			want:    sampleData,
+			wantErr: false,
+		},
+		{
+			name: "failure",
+			fields: fields{
+				mockVendorDBAccessor: NewMockvendorDBAccessor(ctrl),
+			},
+			args: args{
+				ctx:     context.Background(),
+				product: product,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			v := &VendorService{
+				vendorDBAccessor: tt.fields.mockVendorDBAccessor,
+			}
+
+			if tt.wantErr {
+				tt.fields.mockVendorDBAccessor.EXPECT().
+					GetByProduct(tt.args.ctx, tt.args.product).
+					Return(nil, fmt.Errorf("some error"))
+			} else {
+				tt.fields.mockVendorDBAccessor.EXPECT().
+					GetByProduct(tt.args.ctx, tt.args.product).
+					Return(tt.want, nil)
+			}
+
+			res, err := v.GetByProduct(tt.args.ctx, tt.args.product)
+
+			if tt.wantErr {
+				g.Expect(err).ToNot(gomega.BeNil())
+				g.Expect(res).To(gomega.BeNil())
+			} else {
+				g.Expect(err).To(gomega.BeNil())
+				g.Expect(res).To(gomega.Equal(tt.want))
+			}
+		})
+	}
+}

--- a/internal/vendors/service_test.go
+++ b/internal/vendors/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"kg/procurement/internal/common/database"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -271,13 +272,14 @@ func TestVendorService_GetByProduct(t *testing.T) {
 				vendorDBAccessor: tt.fields.mockVendorDBAccessor,
 			}
 
+			productWords := strings.Fields(tt.args.product)
 			if tt.wantErr {
 				tt.fields.mockVendorDBAccessor.EXPECT().
-					GetByProduct(tt.args.ctx, tt.args.product).
+					GetByProductWords(tt.args.ctx, productWords).
 					Return(nil, fmt.Errorf("some error"))
 			} else {
 				tt.fields.mockVendorDBAccessor.EXPECT().
-					GetByProduct(tt.args.ctx, tt.args.product).
+					GetByProductWords(tt.args.ctx, productWords).
 					Return(tt.want, nil)
 			}
 

--- a/router/vendor.go
+++ b/router/vendor.go
@@ -36,4 +36,17 @@ func NewVendorEngine(
 
 		ctx.JSON(http.StatusOK, res)
 	})
+
+	r.GET(cfg.GetByProduct, func(ctx *gin.Context) {
+		product := ctx.Query("product")
+
+		res, err := vendorSvc.GetByProduct(ctx, product)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+		}
+
+		ctx.JSON(http.StatusOK, res)
+	})
 }


### PR DESCRIPTION
## Describe your changes
- Create test for get all vendor by product accessor
- Create test for get all vendor by product service
- Add get all vendor by product accessor implementation
- Add get all vendor by product service implementation
- Refactor redundant and unnecesarry code in get all vendor by location accessor UT
- Add get all vendor by product router

## Issue ticket number and link
- ADU-20: https://linear.app/adudu/issue/ADU-20/filter-vendors-by-product-api
- ADU-29: https://linear.app/adudu/issue/ADU-29/ut-for-filter-vendors-by-product-api