### PR TITLE
PBI 181: Default email template

### DIFF
--- a/internal/vendors/contract.go
+++ b/internal/vendors/contract.go
@@ -6,6 +6,6 @@ type EmailBlastContract struct {
 }
 
 type emailTemplate struct {
-	Subject string `json:"subject" binding:"required"`
-	Body    string `json:"body" binding:"required"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
 }

--- a/internal/vendors/service.go
+++ b/internal/vendors/service.go
@@ -56,6 +56,8 @@ func (v *VendorService) BlastEmail(ctx context.Context, vendorIDs []string, temp
 		return nil, err
 	}
 
+	v.applyDefaultEmailTemplate(&template)
+
 	errCh := make(chan error, len(vendors))
 	defer close(errCh)
 
@@ -106,7 +108,15 @@ func (v *VendorService) BlastEmail(ctx context.Context, vendorIDs []string, temp
 
 func (v *VendorService) AutomatedEmailBlast(ctx context.Context, productName string) ([]string, error) {
 	return v.vendorDBAccessor.getAllVendorIdByProductName(ctx, productName)
+}
 
+func (*VendorService) applyDefaultEmailTemplate(template *emailTemplate) {
+	if template.Subject == "" {
+		template.Subject = "Request for products"
+	}
+	if template.Body == "" {
+		template.Body = "Kepada Yth {{name}},\n\nKami mengajukan permintaan untuk pengadaan produk tertentu yang dibutuhkan oleh perusahaan kami. Mohon informasi mengenai ketersediaan, harga, dan waktu pengiriman untuk produk tersebut.\n\nTerima kasih atas perhatian dan kerjasamanya.\n\nHormat kami"
+	}
 }
 
 func NewVendorService(


### PR DESCRIPTION
## Describe your changes
- Changed the binding validation for `emailTemplate` to accommodate for the new default email template if not provided use case
- Apply default values for unfilled `emailTemplate` fields

## Issue ticket number and link
- https://linear.app/adudu/issue/ADU-181/fe-and-be-create-the-same-default-template

<img width="1353" alt="Screenshot 2024-11-12 at 22 15 15" src="https://github.com/user-attachments/assets/5ee974c3-cbfe-48f7-a650-74fc577cb75e">

