### PR TITLE
PBI 202: Edit Emailed Vendors Status

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,7 +38,7 @@ jobs:
             -Dsonar.tests=.
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.exclusions=**/migrations/**,**/fixtures/**,**/scripts/**,**/vendor/**,**/*_mock.go,internal/common/database/**
-            -Dsonar.coverage.exclusions=**/router/**,**/vendor/**,**/*_mock.go,**/*_test.go,**/cmd/**/*.*,**/internal/mailer/mailer.go
+            -Dsonar.coverage.exclusions=**/router/**,**/vendor/**,**/*_mock.go,**/*_test.go,**/cmd/**/*.*
             -Dsonar.cpd.exclusions=**/accessor.go,**/*.sql
             -Dsonar.language=go
             -Dsonar.sourceEncoding=UTF-8

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,7 +38,7 @@ jobs:
             -Dsonar.tests=.
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.exclusions=**/migrations/**,**/fixtures/**,**/scripts/**,**/vendor/**,**/*_mock.go,internal/common/database/**
-            -Dsonar.coverage.exclusions=**/router/**,**/vendor/**,**/*_mock.go,**/*_test.go,**/cmd/**/*.*
+            -Dsonar.coverage.exclusions=**/router/**,**/vendor/**,**/*_mock.go,**/*_test.go,**/cmd/**/*.*,**/internal/mailer/mailer.go
             -Dsonar.cpd.exclusions=**/accessor.go,**/*.sql
             -Dsonar.language=go
             -Dsonar.sourceEncoding=UTF-8

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -81,7 +81,8 @@ type AccountRoutes struct {
 }
 
 type EmailStatusRoutes struct {
-	GetAll string `mapstructure:"get-all" validate:"required"`
+	GetAll            string `mapstructure:"get-all" validate:"required"`
+	UpdateEmailStatus string `mapstructure:"update-email-status" validate:"required"`
 }
 
 func Load() Application {

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -29,7 +29,8 @@
       "get-current-user": "/account/user"
     },
     "email-status": {
-      "get-all": "/email-status" // email
+      "get-all": "/email-status", // email
+      "update-email-status": "/email-status/:id"
     }
   },
   "token": {

--- a/internal/mailer/accessor.go
+++ b/internal/mailer/accessor.go
@@ -44,14 +44,14 @@ func (p *postgresEmailStatusAccessor) UpdateEmailStatus(_ context.Context, es Em
 	var updatedEmailStatus EmailStatus
 	rows, err := p.db.NamedQuery(updateEmailStatus, es)
 	if err != nil {
-		log.Printf("error updating email status: %v", err)
+		utils.Logger.Errorf("error updating email status: %v", err)
 		return nil, err
 	}
 	defer rows.Close()
 
 	if rows.Next() {
 		if err := rows.StructScan(&updatedEmailStatus); err != nil {
-			log.Printf("error scanning updated email status: %v", err)
+			utils.Logger.Errorf("error scanning updated email status: %v", err)
 			return nil, err
 		}
 	}

--- a/internal/mailer/accessor_test.go
+++ b/internal/mailer/accessor_test.go
@@ -464,6 +464,104 @@ func Test_Close(t *testing.T) {
 	})
 }
 
+func Test_UpdateEmailStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		var (
+			ctx         = context.Background()
+			c           = setupEmailStatusAccessorTestComponent(t, WithQueryMatcher(sqlmock.QueryMatcherRegexp))
+			now         = c.cmock.Now()
+			emailStatus = EmailStatus{
+				ID:           "123",
+				EmailTo:      "email@email.com",
+				Status:       "sent",
+				ModifiedDate: now,
+			}
+		)
+
+		transformedQuery, args, _ := sqlx.Named(updateEmailStatus, emailStatus)
+		driverArgs := make([]driver.Value, len(args))
+		for i, arg := range args {
+			driverArgs[i] = arg
+		}
+
+		rows := sqlmock.NewRows([]string{"id", "email_to", "status", "modified_date"}).
+			AddRow(emailStatus.ID, emailStatus.EmailTo, emailStatus.Status, emailStatus.ModifiedDate)
+
+		c.mock.ExpectQuery(regexp.QuoteMeta(transformedQuery)).WithArgs(
+			driverArgs...,
+		).WillReturnRows(rows)
+
+		updatedEmailStatus, err := c.accessor.UpdateEmailStatus(ctx, emailStatus)
+		c.g.Expect(err).Should(gomega.BeNil())
+		c.g.Expect(updatedEmailStatus).ShouldNot(gomega.BeNil())
+		c.g.Expect(updatedEmailStatus.ID).Should(gomega.Equal(emailStatus.ID))
+		c.g.Expect(updatedEmailStatus.EmailTo).Should(gomega.Equal(emailStatus.EmailTo))
+		c.g.Expect(updatedEmailStatus.Status).Should(gomega.Equal(emailStatus.Status))
+		c.g.Expect(updatedEmailStatus.ModifiedDate).Should(gomega.Equal(emailStatus.ModifiedDate))
+	})
+
+	t.Run("error on row scan", func(t *testing.T) {
+		var (
+			ctx         = context.Background()
+			c           = setupEmailStatusAccessorTestComponent(t, WithQueryMatcher(sqlmock.QueryMatcherRegexp))
+			now         = c.cmock.Now()
+			emailStatus = EmailStatus{
+				ID:           "123",
+				EmailTo:      "email@email.com",
+				Status:       "sent",
+				ModifiedDate: now,
+			}
+		)
+
+		transformedQuery, args, _ := sqlx.Named(updateEmailStatus, emailStatus)
+		driverArgs := make([]driver.Value, len(args))
+		for i, arg := range args {
+			driverArgs[i] = arg
+		}
+
+		rows := sqlmock.NewRows([]string{"id", "email_to", "status", "modified_date"}).
+			AddRow(nil, nil, nil, nil)
+
+		c.mock.ExpectQuery(regexp.QuoteMeta(transformedQuery)).WithArgs(
+			driverArgs...,
+		).WillReturnRows(rows)
+
+		updatedEmailStatus, err := c.accessor.UpdateEmailStatus(ctx, emailStatus)
+		c.g.Expect(err).Should(gomega.HaveOccurred())
+		c.g.Expect(updatedEmailStatus).Should(gomega.BeNil())
+	})
+
+	t.Run("error on db failure", func(t *testing.T) {
+		var (
+			ctx         = context.Background()
+			c           = setupEmailStatusAccessorTestComponent(t)
+			now         = c.cmock.Now()
+			emailStatus = EmailStatus{
+				ID:           "123",
+				EmailTo:      "email@email.com",
+				Status:       "sent",
+				ModifiedDate: now,
+			}
+		)
+
+		transformedQuery, args, _ := sqlx.Named(updateEmailStatus, emailStatus)
+		driverArgs := make([]driver.Value, len(args))
+		for i, arg := range args {
+			driverArgs[i] = arg
+		}
+
+		c.mock.ExpectQuery(regexp.QuoteMeta(transformedQuery)).WithArgs(
+			driverArgs...,
+		).WillReturnError(sql.ErrConnDone)
+
+		updatedEmailStatus, err := c.accessor.UpdateEmailStatus(ctx, emailStatus)
+		c.g.Expect(err).Should(gomega.HaveOccurred())
+		c.g.Expect(updatedEmailStatus).Should(gomega.BeNil())
+	})
+}
+
 type emailStatusAccessorTestComponent struct {
 	g        *gomega.WithT
 	mock     sqlmock.Sqlmock

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -2,6 +2,7 @@
 package mailer
 
 import (
+	"errors"
 	"kg/procurement/internal/common/database"
 	"time"
 )
@@ -27,8 +28,46 @@ type EmailProvider interface {
 
 type GetAllEmailStatusSpec struct {
 	ID           string    `db:"id" json:"id"`
-	EmailTo      string    `db:"email_to" json:"email_to"`
-	Status       string    `db:"status" json:"status"`
-	ModifiedDate time.Time `db:"modified_date" json:"modified_date"`
+	EmailTo      string    `db:"email_to"`
+	Status       string    `db:"status"`
+	ModifiedDate time.Time `db:"modified_date"`
 	database.PaginationSpec
+}
+
+type EmailStatusEnum int64
+
+const (
+	Success EmailStatusEnum = iota
+	Failed
+	InProgress
+	Completed
+)
+
+func (s EmailStatusEnum) String() string {
+	switch s {
+	case Success:
+		return "success"
+	case Failed:
+		return "failed"
+	case InProgress:
+		return "in_progress"
+	case Completed:
+		return "completed"
+	}
+	return "unknown"
+}
+
+func ParseEmailStatusEnum(status string) (EmailStatusEnum, error) {
+	switch status {
+	case "success":
+		return Success, nil
+	case "failed":
+		return Failed, nil
+	case "in_progress":
+		return InProgress, nil
+	case "completed":
+		return Completed, nil
+	default:
+		return -1, errors.New("invalid email status")
+	}
 }

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -28,9 +28,9 @@ type EmailProvider interface {
 
 type GetAllEmailStatusSpec struct {
 	ID           string    `db:"id" json:"id"`
-	EmailTo      string    `db:"email_to"`
-	Status       string    `db:"status"`
-	ModifiedDate time.Time `db:"modified_date"`
+	EmailTo      string    `db:"email_to" json:"email_to"`
+	Status       string    `db:"status" json:"status"`
+	ModifiedDate time.Time `db:"modified_date" json:"modified_date"`
 	database.PaginationSpec
 }
 

--- a/internal/mailer/mailer_test.go
+++ b/internal/mailer/mailer_test.go
@@ -1,0 +1,50 @@
+
+package mailer
+
+import (
+	"testing"
+)
+
+func TestEmailStatusEnum_String(t *testing.T) {
+	tests := []struct {
+		status   EmailStatusEnum
+		expected string
+	}{
+		{Success, "success"},
+		{Failed, "failed"},
+		{InProgress, "in_progress"},
+		{Completed, "completed"},
+		{EmailStatusEnum(999), "unknown"},
+	}
+
+	for _, test := range tests {
+		result := test.status.String()
+		if result != test.expected {
+			t.Errorf("Expected %s, but got %s", test.expected, result)
+		}
+	}
+}
+
+func TestParseEmailStatusEnum(t *testing.T) {
+	tests := []struct {
+		status   string
+		expected EmailStatusEnum
+		err      bool
+	}{
+		{"success", Success, false},
+		{"failed", Failed, false},
+		{"in_progress", InProgress, false},
+		{"completed", Completed, false},
+		{"invalid", -1, true},
+	}
+
+	for _, test := range tests {
+		result, err := ParseEmailStatusEnum(test.status)
+		if (err != nil) != test.err {
+			t.Errorf("Expected error: %v, but got error: %v", test.err, err)
+		}
+		if result != test.expected {
+			t.Errorf("Expected %d, but got %d", test.expected, result)
+		}
+	}
+}

--- a/internal/mailer/service.go
+++ b/internal/mailer/service.go
@@ -11,6 +11,7 @@ import (
 type emailStatusDBAccessor interface {
 	WriteEmailStatus(ctx context.Context, payload EmailStatus) error
 	GetAll(ctx context.Context, spec GetAllEmailStatusSpec) (*AccessorGetAllPaginationData, error)
+	UpdateEmailStatus(ctx context.Context, payload EmailStatus) (*EmailStatus, error)
 }
 
 type EmailStatusService struct {
@@ -23,6 +24,10 @@ func (p *EmailStatusService) WriteEmailStatus(ctx context.Context, payload Email
 
 func (p *EmailStatusService) GetAllEmailStatus(ctx context.Context, spec GetAllEmailStatusSpec) (*AccessorGetAllPaginationData, error) {
 	return p.emailStatusDBAccessor.GetAll(ctx, spec)
+}
+
+func (p *EmailStatusService) UpdateEmailStatus(ctx context.Context, payload EmailStatus) (*EmailStatus, error) {
+	return p.emailStatusDBAccessor.UpdateEmailStatus(ctx, payload)
 }
 
 func NewEmailStatusService(

--- a/internal/mailer/service_mock.go
+++ b/internal/mailer/service_mock.go
@@ -78,6 +78,45 @@ func (c *MockemailStatusDBAccessorGetAllCall) DoAndReturn(f func(context.Context
 	return c
 }
 
+// UpdateEmailStatus mocks base method.
+func (m *MockemailStatusDBAccessor) UpdateEmailStatus(ctx context.Context, payload EmailStatus) (*EmailStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateEmailStatus", ctx, payload)
+	ret0, _ := ret[0].(*EmailStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateEmailStatus indicates an expected call of UpdateEmailStatus.
+func (mr *MockemailStatusDBAccessorMockRecorder) UpdateEmailStatus(ctx, payload any) *MockemailStatusDBAccessorUpdateEmailStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEmailStatus", reflect.TypeOf((*MockemailStatusDBAccessor)(nil).UpdateEmailStatus), ctx, payload)
+	return &MockemailStatusDBAccessorUpdateEmailStatusCall{Call: call}
+}
+
+// MockemailStatusDBAccessorUpdateEmailStatusCall wrap *gomock.Call
+type MockemailStatusDBAccessorUpdateEmailStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockemailStatusDBAccessorUpdateEmailStatusCall) Return(arg0 *EmailStatus, arg1 error) *MockemailStatusDBAccessorUpdateEmailStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockemailStatusDBAccessorUpdateEmailStatusCall) Do(f func(context.Context, EmailStatus) (*EmailStatus, error)) *MockemailStatusDBAccessorUpdateEmailStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockemailStatusDBAccessorUpdateEmailStatusCall) DoAndReturn(f func(context.Context, EmailStatus) (*EmailStatus, error)) *MockemailStatusDBAccessorUpdateEmailStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // WriteEmailStatus mocks base method.
 func (m *MockemailStatusDBAccessor) WriteEmailStatus(ctx context.Context, payload EmailStatus) error {
 	m.ctrl.T.Helper()

--- a/internal/mailer/service_test.go
+++ b/internal/mailer/service_test.go
@@ -66,6 +66,65 @@ func TestEmailStatusService_WriteEmailStatus(t *testing.T) {
 	})
 }
 
+func TestEmailStatusService_UpdateEmailStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		now        = time.Now()
+		updateSpec = EmailStatus{
+			ID:           "some_id",
+			EmailTo:      "email@email.com",
+			Status:       "delivered",
+			ModifiedDate: now,
+		}
+		updatedEmailStatus = &EmailStatus{
+			ID:           "some_id",
+			EmailTo:      "email@email.com",
+			Status:       "delivered",
+			ModifiedDate: now,
+		}
+	)
+
+	t.Run("success", func(t *testing.T) {
+		var (
+			g                       = gomega.NewWithT(t)
+			ctx                     = context.Background()
+			mockCtrl                = gomock.NewController(t)
+			mockEmailStatusAccessor = NewMockemailStatusDBAccessor(mockCtrl)
+		)
+
+		svc := &EmailStatusService{
+			emailStatusDBAccessor: mockEmailStatusAccessor,
+		}
+
+		mockEmailStatusAccessor.EXPECT().UpdateEmailStatus(ctx, updateSpec).Return(updatedEmailStatus, nil)
+
+		result, err := svc.UpdateEmailStatus(ctx, updateSpec)
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(result).To(gomega.Equal(updatedEmailStatus))
+	})
+
+	t.Run("returns error on accessor failure", func(t *testing.T) {
+		var (
+			g                       = gomega.NewWithT(t)
+			ctx                     = context.Background()
+			mockCtrl                = gomock.NewController(t)
+			mockEmailStatusAccessor = NewMockemailStatusDBAccessor(mockCtrl)
+		)
+
+		svc := &EmailStatusService{
+			emailStatusDBAccessor: mockEmailStatusAccessor,
+		}
+
+		mockEmailStatusAccessor.EXPECT().UpdateEmailStatus(ctx, updateSpec).Return(nil, errors.New("update error"))
+
+		result, err := svc.UpdateEmailStatus(ctx, updateSpec)
+		g.Expect(err).ShouldNot(gomega.BeNil())
+		g.Expect(result).To(gomega.BeNil())
+	})
+}
+
 func TestEmailService_GetAll(t *testing.T) {
 	// Sample data to be returned by the mock accessor
 	sampleData := []EmailStatus{

--- a/internal/vendors/service.go
+++ b/internal/vendors/service.go
@@ -134,10 +134,10 @@ func (v *VendorService) executeBlastEmail(ctx context.Context, vendors []Vendor,
 			}
 
 			if sendErr != nil {
-				emailStatus.Status = "failed"
+				emailStatus.Status = mailer.Failed.String()
 				errCh <- sendErr
 			} else {
-				emailStatus.Status = "success"
+				emailStatus.Status = mailer.Success.String()
 				errCh <- nil
 			}
 

--- a/router/email-status.go
+++ b/router/email-status.go
@@ -34,4 +34,38 @@ func NewEmailStatusEngine(
 
 		ctx.JSON(http.StatusOK, res)
 	})
+
+	r.PUT(cfg.UpdateEmailStatus, func(ctx *gin.Context) {
+		utils.Logger.Info("Received updateEmailStatus request")
+
+		id := ctx.Param("id")
+		var payload mailer.EmailStatus
+		if err := ctx.ShouldBindJSON(&payload); err != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		if payload.Status == "" {
+			ctx.JSON(http.StatusBadRequest, gin.H{
+				"error": "status field cannot be empty",
+			})
+			return
+		}
+
+		payload.ID = id
+
+		updatedStatus, err := emailStatusSvc.UpdateEmailStatus(ctx, payload)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		utils.Logger.Info("Completed updateEmailStatus request process")
+
+		ctx.JSON(http.StatusOK, updatedStatus)
+	})
 }

--- a/router/email-status.go
+++ b/router/email-status.go
@@ -53,6 +53,12 @@ func NewEmailStatusEngine(
 			})
 			return
 		}
+		if _, err := mailer.ParseEmailStatusEnum(payload.Status); err != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
 
 		payload.ID = id
 


### PR DESCRIPTION
## Describe your changes
- Create Email Status Enum
- Implement accessor for updateEmailStatus
- Implement service for updateEmailStatus
- Implement router for updateEmailStatus
- Add UT for service and accessor

## Issue ticket number and link
- ADU-202: https://linear.app/adudu/issue/ADU-202/backend-edit-emailed-vendors-status

## Working Snapshots
- Failed:
![image](https://github.com/user-attachments/assets/5df6b43d-9fe0-42ae-94ca-14126b690331)

- Success
![image](https://github.com/user-attachments/assets/bde5394a-b402-4b06-b141-c0ea7eb0709f)

- Before:
![image](https://github.com/user-attachments/assets/a41fbad0-27b6-4a25-91b8-e80312747302)

- After:
![image](https://github.com/user-attachments/assets/8dee7cef-6ba3-4311-b116-b4bf22e68433)
