### PR TITLE
PBI-224: Add EmailTo filter into API

### DIFF
--- a/router/email-status.go
+++ b/router/email-status.go
@@ -19,6 +19,7 @@ func NewEmailStatusEngine(
 
 		paginationSpec := GetPaginationSpec(ctx.Request)
 		spec := mailer.GetAllEmailStatusSpec{
+			EmailTo:        ctx.Query("email_to"),
 			PaginationSpec: paginationSpec,
 		}
 


### PR DESCRIPTION
## Describe your changes
Added a new filter `EmailTo` to the `GetAllEmailStatus` API endpoint to allow users to retrieve email statuses based on the recipient's email address.

## Issue ticket number and link
https://linear.app/adudu/issue/ADU-224/add-emailto-filter-to-getallemailstatus-api

![image](https://github.com/user-attachments/assets/2e18ecb9-01e2-43e0-940f-bf4611aaa655)
