### PR TITLE
PBI-210: Add handling empty email status

### DIFF
--- a/internal/vendors/service.go
+++ b/internal/vendors/service.go
@@ -203,6 +203,15 @@ func (v *VendorService) GetPopulatedEmailStatus(
 		utils.Logger.Errorf("Error fetching email statuses: %v", err)
 		return nil, err
 	}
+
+	if len(emailStatus.EmailStatus) == 0 {
+		utils.Logger.Infof("No email statuses found for the given spec.")
+		return &mailer.GetAllEmailStatusResponse{
+			EmailStatus: []mailer.EmailStatusResponse{},
+			Metadata:    emailStatus.Metadata,
+		}, nil
+	}
+
 	res := mailer.GetAllEmailStatusResponse{}
 	var vendorIDs []string
 	for _, es := range emailStatus.EmailStatus {

--- a/internal/vendors/service_test.go
+++ b/internal/vendors/service_test.go
@@ -795,13 +795,13 @@ func TestVendorService_GetPopulatedEmailStatus(t *testing.T) {
 
 		sampleVendors := []Vendor{
 			{
-				ID:   "vendor1",
-				Name: "Vendor 1",
+				ID:     "vendor1",
+				Name:   "Vendor 1",
 				Rating: 100,
 			},
 			{
-				ID:   "vendor2",
-				Name: "Vendor 2",
+				ID:     "vendor2",
+				Name:   "Vendor 2",
 				Rating: 50,
 			},
 		}
@@ -825,6 +825,27 @@ func TestVendorService_GetPopulatedEmailStatus(t *testing.T) {
 
 		g.Expect(result.EmailStatus[0].VendorName).To(gomega.Equal("Vendor 1"))
 		g.Expect(result.EmailStatus[1].VendorName).To(gomega.Equal("Vendor 2"))
+	})
+
+	t.Run("no email statuses found", func(t *testing.T) {
+		g := setup(t)
+
+		mockEmailStatusSvc.EXPECT().GetAllEmailStatus(gomock.Any(), gomock.Any()).Return(
+			&mailer.AccessorGetEmailStatusPaginationData{
+				EmailStatus: []mailer.EmailStatus{},
+				Metadata: database.PaginationMetadata{
+					TotalPage:   1,
+					CurrentPage: 1,
+				},
+			}, nil)
+
+		result, err := service.GetPopulatedEmailStatus(context.Background(), mailer.GetAllEmailStatusSpec{})
+
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(result).ToNot(gomega.BeNil())
+		g.Expect(result.EmailStatus).To(gomega.HaveLen(0))
+		g.Expect(result.Metadata.TotalPage).To(gomega.Equal(1))
+		g.Expect(result.Metadata.CurrentPage).To(gomega.Equal(1))
 	})
 
 	t.Run("vendor not found", func(t *testing.T) {


### PR DESCRIPTION
## Describe your changes
Handle cases where no email statuses are returned by ensuring the response contains an empty EmailStatus slice and valid metadata without errors.

## Issue ticket number and link
https://linear.app/adudu/issue/ADU-229/add-handling-empty-email-status